### PR TITLE
Add K8s configs and docs for ingress without AWS stuff

### DIFF
--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -47,17 +47,6 @@ module "eks" {
     }
   }
 
-  node_security_group_additional_rules = {
-    ingress_allow_access_from_control_plane = {
-      type                          = "ingress"
-      protocol                      = "tcp"
-      from_port                     = 9443
-      to_port                       = 9443
-      source_cluster_security_group = true
-      description                   = "Allow access from control plane to webhook port of AWS Load Balancer Controller"
-    }
-  }
-
   # aws-auth configmap
   manage_aws_auth_configmap = true
 

--- a/k8s-examples/README.md
+++ b/k8s-examples/README.md
@@ -1,0 +1,55 @@
+
+# Deploying the `hello-kubernetes` App to AWS EKS
+
+## How to Verify, Step by Step
+
+*Prerequisites:* Have the Terraform CLI installed, ensure the EKS cluster is set up, configure `kubectl` to use it, and
+have Helm installed.
+
+Step 1, verify you have Helm available and can add a repo:
+
+    helm version && helm repo add eks https://aws.github.io/eks-charts
+
+Step 2, verify you can get the cluster name output via Terraform:
+
+    export CLUSTER_NAME=$(terraform output -raw cluster_name) && echo $CLUSTER_NAME
+
+Step 3, verify your Terraform cluster endpoint matches the `kubectl` config:
+
+    kubectl cluster-info && echo "\\nControl plane URL matches '$(terraform output -raw cluster_endpoint)'? Good!"
+
+Step 4, install the AWS Load Balancer Controller:
+
+    helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
+      --set autoDiscoverAwsRegion=true \
+      --set autoDiscoverAwsVpcID=true \
+      --set clusterName=$CLUSTER_NAME
+
+Step 5, apply the Deployment, Service, and Ingress K8s configs:
+
+    kubectl apply -f hello-kubernetes-deployment.yml
+    kubectl apply -f hello-kubernetes-service.yml
+    kubectl apply -f hello-kubernetes-ingress.yml
+
+Step 6, wait for the AWS Application Load Balancer to be configured and invoke _`kubectl describe`_ on it until
+the _Address_ field is populated with an URL:
+
+    kubectl describe ingress hello-kubernetes
+
+Step 7, open the address in your browser and expect to be greeted with a "Hello world!" Kubernetes page (example URL,
+[works on my computer](http://k8s-default-hellokub-119340f37d-1621773271.eu-north-1.elb.amazonaws.com)):
+
+    open k8s-default-hellokub-119340f37d-1621773271.eu-north-1.elb.amazonaws.com
+
+
+## Attributions
+
+All of this is stolen from the [`learnk8s`/"Provisioning Kubernetes clusters on AWS with Terraform and EKS" guide](https://learnk8s.io/terraform-eks#testing-the-cluster-by-deploying-a-simple-hello-world-app),
+thanks @k-mitevski!
+
+
+## Contributing
+
+Do you want to make this work with a secure and stylish `https://my-cool-app.domain.top` URL? Reach out to the owner and
+let's get some mob programming going! Or open a ticket/issue pointing to how this integrates well with AWS Certificate
+Manager and/or Route 53

--- a/k8s-examples/hello-kubernetes-deployment.yml
+++ b/k8s-examples/hello-kubernetes-deployment.yml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-kubernetes
+spec:
+  selector:
+    matchLabels:
+      name: hello-kubernetes
+  template:
+    metadata:
+      labels:
+        name: hello-kubernetes
+    spec:
+      containers:
+        - name: app
+          image: paulbouwer/hello-kubernetes:1.10.1
+          ports:
+            - containerPort: 8080
+

--- a/k8s-examples/hello-kubernetes-ingress.yml
+++ b/k8s-examples/hello-kubernetes-ingress.yml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hello-kubernetes
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    kubernetes.io/ingress.class: alb
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: hello-kubernetes
+                port:
+                  number: 80

--- a/k8s-examples/hello-kubernetes-service.yml
+++ b/k8s-examples/hello-kubernetes-service.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello-kubernetes
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: 8080
+  selector:
+    name: hello-kubernetes


### PR DESCRIPTION
All following the guide [`learnk8s`/"Provisioning Kubernetes clusters on AWS with Terraform and EKS"](https://learnk8s.io/terraform-eks#testing-the-cluster-by-deploying-a-simple-hello-world-app). Thanks @Kristijan!

Also: Revert the "Allow Ingress on Port 9443 from EKS Control Plane..." from PR #7 (rule already provided by default, it seems)