### PR TITLE
Replace ALB ingress with Nginx Ingress Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,180 @@
-# Terraform Cloud Getting Started Guide Example
 
-This is an example Terraform configuration intended for use with the [Terraform Cloud Getting Started Guide](https://learn.hashicorp.com/terraform/cloud-gettingstarted/tfc_overview).
+# Terraform Cloud AWS EKS Setup
 
-## What will this do?
+## What will This Do?
 
-This is a Terraform configuration that will create an EC2 instance in your AWS account. 
+This Terraform configuration will setup a EKS cluster in your AWS account, then provision
+a [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/) for the Kubernetes
+cluster and setup DNS names for it. Finally, it will deploy a couple of deplyoments exposed to the world via
+the [Nginx Ingress Controller](https://aws.amazon.com/premiumsupport/knowledge-center/eks-access-kubernetes-services/).
 
-When you set up a Workspace on Terraform Cloud, you can link to this repository. Terraform Cloud can then run `terraform plan` and `terraform apply` automatically when changes are pushed. For more information on how Terraform Cloud interacts with Version Control Systems, see [our VCS documentation](https://www.terraform.io/docs/cloud/run/ui.html).
+## What are the Pre-Requisites?
 
-## What are the prerequisites?
+You must have an AWS account and provide your AWS Access Key ID and AWS Secret Access Key to Terraform Cloud.
+Terraform Cloud encrypts and stores variables using [Vault](https://www.vaultproject.io/). You must have the AWS
+and Terraform CLIs installed on your local workstation.
 
-You must have an AWS account and provide your AWS Access Key ID and AWS Secret Access Key to Terraform Cloud. Terraform Cloud encrypts and stores variables using [Vault](https://www.vaultproject.io/). For more information on how to store variables in Terraform Cloud, see [our variable documentation](https://www.terraform.io/docs/cloud/workspaces/variables.html).
+The values for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` should be saved as environment variables on
+your workspace. For more information on how to store variables in Terraform Cloud,
+see [our variable documentation](https://www.terraform.io/docs/cloud/workspaces/variables.html).
 
-The values for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` should be saved as environment variables on your workspace.
+## Getting Started
+
+### 1. Initialize the Base Infrastructure
+
+1. Update the `./terraform.tf` to name your Terraform Cloud `organization` and `workspace` names
+2. Update the `./variables.tf` to use your desired `resource_prefix`, and AWS `account_id` and `region`
+3. Run `terraform init` in the repo root directory
+4. Run `terraform plan && terraform apply` in the repo root and accept the proposed changes if they make sense to you
+5. Open the AWS web console and verify your EKS cluster is up and looking good
+6. Configure your `kubectl` command-line tool to use the new EKS cluster:
+
+       export AWS_PROFILE=default
+       export AWS_REGION=eu-north-1
+       export CLUSTER_NAME=mb-eks-cluster
+       aws --profile=$AWS_PROFILE eks update-kubeconfig --region $AWS_REGION --name $CLUSTER_NAME
+
+7. Verify your local configuration with `kubectl cluster-info`
+
+### 2. Configure the AWS Load Balancer Controller Add-On
+
+Deploy the AWS Load Balancer Controller by following
+the [Amazon EKS User Guide](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html).
+
+First create the `./iam-policies/eks-worker-policy.json` manifest:
+
+    curl -o iam-policies/eks-worker-policy.json \
+      https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.4.4/docs/install/iam_policy.json
+
+Verify that the IAM policy manifest matches the version in Git (indentation ignored).
+
+Then create the IAM policy if it does not already exist (replacing `AWS_PROFILE` export with what matches your locals):
+
+    export AWS_PROFILE=default
+    aws --profile=$AWS_PROFILE iam create-policy \
+      --policy-name AWSLoadBalancerControllerIAMPolicy \
+      --policy-document file://iam-policies/eks-worker-policy.json
+
+Prepare for creating a Kubernetes service account named `aws-load-balancer-controller` in the `kube-system` namespace:
+
+    # Ensure output matches expectation
+    export CLUSTER_NAME=$(terraform output -raw cluster_name) && echo $CLUSTER_NAME
+
+    # Ensure output matches expectation
+    export OIDC_ID=$(aws eks describe-cluster --name $CLUSTER_NAME --query "cluster.identity.oidc.issuer" \
+      --output text | cut -d '/' -f 5) && echo $OIDC_ID
+
+    # Expect output to show the OIDC_ID followed by a trailing "
+    aws iam list-open-id-connect-providers | grep $OIDC_ID | cut -d "/" -f4
+
+Review the `./iam-policies/load-balancer-role-trust-policy.json` manifest, replace account ID `878179636352` with
+your own account number, `B498DC54986685B28E8A1F146AC30099` with your own OIDC ID, and `eu-north-1` with your own region
+and create the IAM role (and replacing `AWS_PROFILE` export with what matches your locals):
+
+    export AWS_PROFILE=default
+    aws --profile=$AWS_PROFILE iam create-role \
+      --role-name AmazonEKSLoadBalancerControllerRole \
+      --assume-role-policy-document file://"iam-policies/load-balancer-role-trust-policy.json"
+
+Attach the IAM policy to the IAM role, replacing account ID `878179636352` with your own account number:
+
+    export AWS_PROFILE=default
+    aws --profile=$AWS_PROFILE iam attach-role-policy \
+      --policy-arn arn:aws:iam::878179636352:policy/AWSLoadBalancerControllerIAMPolicy \
+      --role-name AmazonEKSLoadBalancerControllerRole
+
+Review the `./iam-policies/aws-load-balancer-controller-service-account.yaml` manifest and replace account ID
+`878179636352` with your own account number and apply on your Kubernetes cluster:
+
+     kubectl apply -f iam-policies/aws-load-balancer-controller-service-account.yaml
+
+Install the AWS Load Balancer Controller using [Helm V3](https://docs.aws.amazon.com/eks/latest/userguide/helm.html) or
+later by applying the Kubernetes manifest:
+
+    # Ensure output matches expectation
+    export CLUSTER_NAME=$(terraform output -raw cluster_name) && echo $CLUSTER_NAME
+
+    helm repo add eks https://aws.github.io/eks-charts
+    helm repo update
+    helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
+      -n kube-system \
+      --set clusterName=$CLUSTER_NAME \
+      --set serviceAccount.create=false \
+      --set serviceAccount.name=aws-load-balancer-controller
+
+Verify that the controller is installed:
+
+    kubectl get deployment -n kube-system aws-load-balancer-controller
+
+Example success output:
+
+    kubectl get deployment -n kube-system aws-load-balancer-controller
+    "NAME                           READY   UP-TO-DATE   AVAILABLE   AGE"
+    "aws-load-balancer-controller   2/2     2            2           22h"
+
+### 3. Deploy the Nginx Ingress Controller for Kubernetes
+
+Deploy the Nginx Ingress Controller, "Option 2", by following the AWS
+[External Access to Kubernetes](https://aws.amazon.com/premiumsupport/knowledge-center/eks-access-kubernetes-services/)
+services guide. Update the `./k8s-infra/deploy-nginx-controller-with-nlb-ssl.yaml` manifest by changing the annotation
+`service.beta.kubernetes.io/aws-load-balancer-ssl-cert` annotation value to use your own account ID instead
+of `878179636352` and your own certificate instead of `3e897236-c6d6-44a8-afca-7554e52797c3`. Apply the updated manifest:
+
+    kubectl apply -f k8s-infra/deploy-nginx-controller-with-nlb-ssl.yaml
+
+### 4. Verify the Deployed Resources
+
+Verify that the AWS Load Balancer Controller is running:
+
+    kubectl get all -n kube-system --selector app.kubernetes.io/instance=aws-load-balancer-controller
+
+Verify that the Nginx Ingress Controller is running:
+
+    kubectl get all -n ingress-nginx --selector app.kubernetes.io/instance=ingress-nginx
+
+Verify that your Kubernetes cluster have ingress classes `alb` and `nginx`:
+
+    kubectl get ingressclass
+
+### 5. Configure DNS with Route53
+
+Get the AWS Load Balancer Endpoint created by the Nginx Ingress Controller:
+
+    kubectl describe -n ingress-nginx service ingress-nginx-controller | grep Ingress | cut -d':' -f2 | xargs
+
+Example:
+
+    "k8s-ingressn-ingressn-d7a33e1924-2dcfed4179033b4a.elb.eu-north-1.amazonaws.com"
+
+Find the matching load balancer in the AWS Web Console under
+[EC2 > Load Balancers](https://eu-north-1.console.aws.amazon.com/ec2/home?region=eu-north-1#LoadBalancers) and
+copy the _Hosted Zone ID_ from the details' view, a string that looks something like `"Z1UDT6IFJ4EJM"`.
+
+Open the [Route 53 > Hosted Zones](https://us-east-1.console.aws.amazon.com/route53/v2/hostedzones#) view in the AWS Web
+Console and copy the _Hosted Zone ID_ from your apex domain hosted zone, something like `"Z1TY55FUWSMGVV"`.
+
+Modify the `./dns/variables.tf` config file by replacing the default value for `eks_elb_domain` and `eks_elb_zone_id`
+with the Load Balancer Endpoint and Load Balancer Hosted Zone ID, and replacing `route53_apex_zone_id` with the
+Apex Domain Hosted Zone ID.
+
+Change directory to `./dns` and apply the Terraform configuration:
+
+    cd dns/
+    terraform init
+    terraform plan
+    terraform apply
+
+### 6. Verify the DNS Setup
+
+Verify that `nslookup` returns 2 records for `mb-eks.smithmicro.io`:
+
+    nslookup mb-eks.smithmicro.io
+
+Verify that `curl` receives a 404 response with valid SSL certificate:
+
+    curl -v https://mb-eks.smithmicro.io
+
+### 7. Deploy a Kubernetes Resource
+
+Follow the setup steps in [./k8s-examples/README.md](./k8s-examples/README.md) to deploy your service and
+verify that it becomes accessible via the DNS pretty-name.

--- a/dns/.terraform.lock.hcl
+++ b/dns/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.51.0"
+  constraints = "~> 4.51.0"
+  hashes = [
+    "h1:gcJ7Wl7NSFTacEekzzkggUTCn9KMsGr8TH2mXrj9EJ4=",
+    "zh:10aebfd8f22f7a69a2fcfcf35cb17ebbc0966ac8e822a9a0e1c843e429389de7",
+    "zh:26661203ab083ec35a5ae2d9b516793d98f4380655bcd304724af7495aaa7c09",
+    "zh:27ad57b820666a252e64959a4369fe9e40df5bf5d37a6ee272cc9131a501448f",
+    "zh:5d7b1acfae1a7835509d8f501e4e731cac2246b9f5b6674b643790d6eaca8037",
+    "zh:62cb21d9c90fd6b7af5c4b4d47f3e2908c3c7087809f3faeb561c4a12b14cbf5",
+    "zh:731490aa24ffe958e23f67619b897c96178a1c628453b02727c69f15dc90ff7b",
+    "zh:7b85f3513da571db05ad43f6a1ba195ab33ce8284f03537b636b561c1ad43075",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9d8f3b176046f438768d8b1ba25d2bb8d234499a2c2c8fa0e1336c84ae708c41",
+    "zh:bec27993d9501fb84df58d7f0b3eed2c8243e61f3676e66de17a9e2a8ff2f5be",
+    "zh:cd27798991a86b44adab3969db96666dde12309caf55e40bffe90bd895a6edd3",
+    "zh:dba49fdf4339a941357944616b1bf79483c2bed31c235e4cd59698802c8d2fdb",
+    "zh:ed1ccf97ec02191e0840ac4fdbd2da21eea661b9d7e11c0f98b71ab67a3d3718",
+    "zh:edeb801e3c84e653dc3449a0b73b64d1ba167cef674863ae5106d9a063548c70",
+    "zh:f680647b4fce3d7603a24ae69c32cf6664fb0182844d00f18ddae3d5d878441c",
+  ]
+}

--- a/dns/main.tf
+++ b/dns/main.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.region
+}

--- a/dns/outputs.tf
+++ b/dns/outputs.tf
@@ -1,0 +1,4 @@
+output "elb_fqdn" {
+  description = "FQDN for K8s Elastic Load Balancer"
+  value       = aws_route53_record.subdomain-elb-alias.fqdn
+}

--- a/dns/route53.tf
+++ b/dns/route53.tf
@@ -1,0 +1,39 @@
+resource "aws_route53_zone" "subdomain" {
+  name = "${var.route53_subdomain}.${var.route53_apex}"
+
+  tags = {
+    Origin         = var.common_origin_tag
+    ResourcePrefix = var.route53_subdomain
+    Owner          = var.common_owner_tag
+    Purpose        = var.common_purpose_tag
+    Stack          = var.common_stack_tag
+  }
+}
+
+resource "aws_route53_record" "subdomain-elb-alias" {
+  zone_id = aws_route53_zone.subdomain.zone_id
+  name    = ""
+  type    = "A"
+
+  alias {
+    name                   = var.eks_elb_domain
+    zone_id                = var.eks_elb_zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "subdomain-cname" {
+  zone_id = aws_route53_zone.subdomain.zone_id
+  name    = "*"
+  type    = "CNAME"
+  ttl     = "300"
+  records = [var.eks_elb_domain]
+}
+
+resource "aws_route53_record" "apex-subdomain-ns" {
+  zone_id = var.route53_apex_zone_id
+  name    = var.route53_subdomain
+  type    = "NS"
+  ttl     = "30"
+  records = aws_route53_zone.subdomain.name_servers
+}

--- a/dns/terraform.tf
+++ b/dns/terraform.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.51.0"
+    }
+  }
+
+  cloud {
+    organization = "mblomdahl"
+
+    workspaces {
+      name = "tfc-vs4345-k8s-dns"
+    }
+  }
+
+  required_version = ">= 1.3.6"
+}

--- a/dns/variables.tf
+++ b/dns/variables.tf
@@ -1,8 +1,3 @@
-variable "resource_prefix" {
-  description = "Prefix for AWS EKS resources (VPCs, EKS cluster/namespace)"
-  default     = "mb-eks"
-}
-
 variable "account_id" {
   description = "AWS account ID"
   default     = "878179636352"
@@ -13,14 +8,29 @@ variable "region" {
   default     = "eu-north-1"
 }
 
-variable "eks_ami_type" {
-  description = "AMI type for AWS EKS node group instances"
-  default     = "AL2_x86_64"
+variable "eks_elb_domain" {
+  description = "Domain for EKS ELB"
+  default     = "k8s-ingressn-ingressn-d7a33e1924-2dcfed4179033b4a.elb.eu-north-1.amazonaws.com"
 }
 
-variable "node_group_instance_type" {
-  description = "Type of AWS EKS node group instances to provision"
-  default     = "t3.small"
+variable "eks_elb_zone_id" {
+  description = "Zone ID for EKS ELB"
+  default     = "Z1UDT6IFJ4EJM"
+}
+
+variable "route53_apex" {
+  description = "Domain for Route 53 hosted zone"
+  default     = "smithmicro.io"
+}
+
+variable "route53_apex_zone_id" {
+  description = "Zone ID for Route 53 apex hosted zone"
+  default     = "Z1TY55FUWSMGVV"
+}
+
+variable "route53_subdomain" {
+  description = "Subdomain name for Route 53 hosted zone"
+  default     = "mb-eks"
 }
 
 variable "common_origin_tag" {

--- a/iam-policies/aws-load-balancer-controller-service-account.yaml
+++ b/iam-policies/aws-load-balancer-controller-service-account.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: aws-load-balancer-controller
+  name: aws-load-balancer-controller
+  namespace: kube-system
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::878179636352:role/AmazonEKSLoadBalancerControllerRole

--- a/iam-policies/load-balancer-role-trust-policy.json
+++ b/iam-policies/load-balancer-role-trust-policy.json
@@ -1,0 +1,18 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Federated": "arn:aws:iam::878179636352:oidc-provider/oidc.eks.eu-north-1.amazonaws.com/id/B498DC54986685B28E8A1F146AC30099"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+                "StringEquals": {
+                    "oidc.eks.eu-north-1.amazonaws.com/id/B498DC54986685B28E8A1F146AC30099:aud": "sts.amazonaws.com",
+                    "oidc.eks.eu-north-1.amazonaws.com/id/B498DC54986685B28E8A1F146AC30099:sub": "system:serviceaccount:kube-system:aws-load-balancer-controller"
+                }
+            }
+        }
+    ]
+}

--- a/k8s-examples/README.md
+++ b/k8s-examples/README.md
@@ -1,55 +1,24 @@
 
 # Deploying the `hello-kubernetes` App to AWS EKS
 
-## How to Verify, Step by Step
+## How to Deploy and Verify, Step by Step
 
-*Prerequisites:* Have the Terraform CLI installed, ensure the EKS cluster is set up, configure `kubectl` to use it, and
-have Helm installed.
+*Prerequisites:* Have the EKS cluster, Nginx Ingress Controller, and DNS configuration set up per the instructions in
+the [root README.md](../README.md).
 
-Step 1, verify you have Helm available and can add a repo:
+Change directory to `./k8s-examples` and apply/verify the Deployment, Service, and Ingress K8s configs:
 
-    helm version && helm repo add eks https://aws.github.io/eks-charts
-
-Step 2, verify you can get the cluster name output via Terraform:
-
-    export CLUSTER_NAME=$(terraform output -raw cluster_name) && echo $CLUSTER_NAME
-
-Step 3, verify your Terraform cluster endpoint matches the `kubectl` config:
-
-    kubectl cluster-info && echo "\\nControl plane URL matches '$(terraform output -raw cluster_endpoint)'? Good!"
-
-Step 4, install the AWS Load Balancer Controller:
-
-    helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
-      --set autoDiscoverAwsRegion=true \
-      --set autoDiscoverAwsVpcID=true \
-      --set clusterName=$CLUSTER_NAME
-
-Step 5, apply the Deployment, Service, and Ingress K8s configs:
-
+    cd k8s-examples/
     kubectl apply -f hello-kubernetes-deployment.yml
+    kubectl get deployment hello-kubernetes -n default
     kubectl apply -f hello-kubernetes-service.yml
+    kubectl get service hello-kubernetes -n default
     kubectl apply -f hello-kubernetes-ingress.yml
+    kubectl describe ingress -n default
 
-Step 6, wait for the AWS Application Load Balancer to be configured and invoke _`kubectl describe`_ on it until
-the _Address_ field is populated with an URL:
+Open the address in your browser and expect to be greeted with a "Hello world!" Kubernetes page (example URL
+[works on my computer](https://mb-eks.smithmicro.io/hello-kubernetes/)):
 
-    kubectl describe ingress hello-kubernetes
+    open https://mb-eks.smithmicro.io/hello-kubernetes/
 
-Step 7, open the address in your browser and expect to be greeted with a "Hello world!" Kubernetes page (example URL,
-[works on my computer](http://k8s-default-hellokub-119340f37d-1621773271.eu-north-1.elb.amazonaws.com)):
-
-    open http://k8s-default-hellokub-119340f37d-1621773271.eu-north-1.elb.amazonaws.com
-
-
-## Attributions
-
-All of this is stolen from the [`learnk8s`/"Provisioning Kubernetes clusters on AWS with Terraform and EKS" guide](https://learnk8s.io/terraform-eks#testing-the-cluster-by-deploying-a-simple-hello-world-app),
-thanks @k-mitevski!
-
-
-## Contributing
-
-Do you want to make this work with a secure and stylish `https://my-cool-app.domain.top` URL? Reach out to the owner and
-let's get some mob programming going! Or open a ticket/issue pointing to how this integrates well with AWS Certificate
-Manager and/or Route 53
+And celebrate!

--- a/k8s-examples/hello-kubernetes-deployment.yml
+++ b/k8s-examples/hello-kubernetes-deployment.yml
@@ -2,7 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-kubernetes
+  namespace: default
 spec:
+  replicas: 2
   selector:
     matchLabels:
       name: hello-kubernetes
@@ -14,6 +16,11 @@ spec:
       containers:
         - name: app
           image: paulbouwer/hello-kubernetes:1.10.1
+          env:
+            - name: MESSAGE
+              value: "Hello world, @mb-eks-cluster!"
+            - name: RENDER_PATH_PREFIX
+              value: /hello-kubernetes/
           ports:
             - containerPort: 8080
 

--- a/k8s-examples/hello-kubernetes-ingress.yml
+++ b/k8s-examples/hello-kubernetes-ingress.yml
@@ -2,17 +2,20 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: hello-kubernetes
+  namespace: default
   annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    kubernetes.io/ingress.class: alb
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
   rules:
-    - http:
+    - host: mb-eks.smithmicro.io
+      http:
         paths:
-          - path: /
+          - path: /hello-kubernetes(/|$)(.*)
             pathType: Prefix
             backend:
               service:
                 name: hello-kubernetes
                 port:
                   number: 80
+

--- a/k8s-examples/hello-kubernetes-service.yml
+++ b/k8s-examples/hello-kubernetes-service.yml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hello-kubernetes
+  namespace: default
 spec:
   type: NodePort
   ports:

--- a/k8s-infra/deploy-nginx-controller-with-nlb-ssl.yaml
+++ b/k8s-infra/deploy-nginx-controller-with-nlb-ssl.yaml
@@ -1,0 +1,675 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+  name: ingress-nginx
+---
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
+  name: ingress-nginx
+  namespace: ingress-nginx
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
+  name: ingress-nginx
+  namespace: ingress-nginx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - secrets
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - ingress-nginx-leader
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - ingress-nginx-leader
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
+  name: ingress-nginx
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - nodes
+  - pods
+  - secrets
+  - namespaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/status
+  verbs:
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
+  name: ingress-nginx-admission
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
+  name: ingress-nginx
+  namespace: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ingress-nginx
+subjects:
+- kind: ServiceAccount
+  name: ingress-nginx
+  namespace: ingress-nginx
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ingress-nginx-admission
+subjects:
+- kind: ServiceAccount
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
+  name: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ingress-nginx
+subjects:
+- kind: ServiceAccount
+  name: ingress-nginx
+  namespace: ingress-nginx
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
+  name: ingress-nginx-admission
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ingress-nginx-admission
+subjects:
+- kind: ServiceAccount
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+---
+apiVersion: v1
+data:
+  allow-snippet-annotations: "true"
+  http-snippet: |
+    server {
+      listen 2443;
+      return 308 https://$host$request_uri;
+    }
+  proxy-real-ip-cidr: 10.181.0.0/16
+  use-forwarded-headers: "true"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:eu-north-1:878179636352:certificate/3e897236-c6d6-44a8-afca-7554e52797c3
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+    service.beta.kubernetes.io/aws-load-balancer-type: "external"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "instance"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - appProtocol: http
+    name: http
+    port: 80
+    protocol: TCP
+    targetPort: tohttps
+  - appProtocol: https
+    name: https
+    port: 443
+    protocol: TCP
+    targetPort: http
+  selector:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+  type: LoadBalancer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
+  name: ingress-nginx-controller-admission
+  namespace: ingress-nginx
+spec:
+  ports:
+  - appProtocol: https
+    name: https-webhook
+    port: 443
+    targetPort: webhook
+  selector:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  minReadySeconds: 0
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: ingress-nginx
+      app.kubernetes.io/name: ingress-nginx
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+    spec:
+      containers:
+      - args:
+        - /nginx-ingress-controller
+        - --publish-service=$(POD_NAMESPACE)/ingress-nginx-controller
+        - --election-id=ingress-nginx-leader
+        - --controller-class=k8s.io/ingress-nginx
+        - --ingress-class=nginx
+        - --configmap=$(POD_NAMESPACE)/ingress-nginx-controller
+        - --validating-webhook=:8443
+        - --validating-webhook-certificate=/usr/local/certificates/cert
+        - --validating-webhook-key=/usr/local/certificates/key
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LD_PRELOAD
+          value: /usr/local/lib/libmimalloc.so
+        image: registry.k8s.io/ingress-nginx/controller:v1.5.1@sha256:4ba73c697770664c1e00e9f968de14e08f606ff961c76e5d7033a4a9c593c629
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /wait-shutdown
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: controller
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        - containerPort: 80
+          name: https
+          protocol: TCP
+        - containerPort: 2443
+          name: tohttps
+          protocol: TCP
+        - containerPort: 8443
+          name: webhook
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 10254
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 90Mi
+        securityContext:
+          allowPrivilegeEscalation: true
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          runAsUser: 101
+        volumeMounts:
+        - mountPath: /usr/local/certificates/
+          name: webhook-cert
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: ingress-nginx
+      terminationGracePeriodSeconds: 300
+      volumes:
+      - name: webhook-cert
+        secret:
+          secretName: ingress-nginx-admission
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
+  name: ingress-nginx-admission-create
+  namespace: ingress-nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: admission-webhook
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.5.1
+      name: ingress-nginx-admission-create
+    spec:
+      containers:
+      - args:
+        - create
+        - --host=ingress-nginx-controller-admission,ingress-nginx-controller-admission.$(POD_NAMESPACE).svc
+        - --namespace=$(POD_NAMESPACE)
+        - --secret-name=ingress-nginx-admission
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20220916-gd32f8c343@sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f
+        imagePullPolicy: IfNotPresent
+        name: create
+        securityContext:
+          allowPrivilegeEscalation: false
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: OnFailure
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 2000
+      serviceAccountName: ingress-nginx-admission
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
+  name: ingress-nginx-admission-patch
+  namespace: ingress-nginx
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: admission-webhook
+        app.kubernetes.io/instance: ingress-nginx
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+        app.kubernetes.io/version: 1.5.1
+      name: ingress-nginx-admission-patch
+    spec:
+      containers:
+      - args:
+        - patch
+        - --webhook-name=ingress-nginx-admission
+        - --namespace=$(POD_NAMESPACE)
+        - --patch-mutating=false
+        - --secret-name=ingress-nginx-admission
+        - --patch-failure-policy=Fail
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v20220916-gd32f8c343@sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f
+        imagePullPolicy: IfNotPresent
+        name: patch
+        securityContext:
+          allowPrivilegeEscalation: false
+      nodeSelector:
+        kubernetes.io/os: linux
+      restartPolicy: OnFailure
+      securityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 2000
+      serviceAccountName: ingress-nginx-admission
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
+  name: nginx
+spec:
+  controller: k8s.io/ingress-nginx
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/component: admission-webhook
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.5.1
+  name: ingress-nginx-admission
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: ingress-nginx-controller-admission
+      namespace: ingress-nginx
+      path: /networking/v1/ingresses
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validate.nginx.ingress.kubernetes.io
+  rules:
+  - apiGroups:
+    - networking.k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - ingresses
+  sideEffects: None

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ locals {
 
 data "aws_eks_cluster" "default" {
   name = local.cluster_name
+  depends_on = [module.eks]
 }
 
 data "aws_eks_cluster_auth" "default" {


### PR DESCRIPTION
- Add explicit dependency from `data.aws_eks_cluster.default` to `module.eks` for initial setup
- Add IAM `aws-load-balancer-controller` service account config
- Add IAM Load Balancer Controller trust policy
- Add Nginx Ingress Controller resources for Kubernetes
- Add new Terraform workspace for configuring DNS, after Kubernetes have created its Elastic Load Balancer
- Update root `README.md` with complete setup instruction
- Update instructions for deploying an example application to Kubernetes with Nginx Ingress Controller