### PR TITLE
Add Setup Instructions for EBS Persistent Storage in EKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,29 @@ see [our variable documentation](https://www.terraform.io/docs/cloud/workspaces/
 7. Verify your local configuration with `kubectl cluster-info`
 
 
-### 2. Configure the AWS Elastic File System Storage
+### 3. Configure the AWS Elastic Block Storage for EKS
 
-Configure persistent storage for EKS by following
-the [Amazon EFS CSI Driver User Guide](https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html).
+Configure persistent storage using EBS for EKS by following
+the [Amazon EBS CSI Driver User Guide](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html), summarized below.
+
+Modify the `./k8s-infra/aws-ebs-csi-driver-service-account.yaml` manifest by
+replacing `"arn:aws:iam::878179636352:role/mb-eks-ebs-csi-driver-role"` with your own role ARN:
+
+    echo $(terraform output -raw iam_aws_ebs_csi_driver_service_account_arn)
+
+Apply the Kubernetes service account configuration for `ebs-csi-controller-sa` and the storage class manifest:
+
+    kubectl apply -f k8s-infra/aws-ebs-csi-driver-service-account.yaml
+    kubectl apply -f k8s-infra/aws-ebs-storageclass.yaml
+
+Follow the steps in [./k8s-examples/ebs-storage/README.md](./k8s-examples/ebs-storage/README.md) to
+verify that EBS persistent volumes and storage claims can be utilized in your cluster.
+
+
+### 3. Configure the AWS Elastic File System Storage
+
+Configure persistent storage using EFS for EKS by following
+the [Amazon EFS CSI Driver User Guide](https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html), summarized below.
 
 Modify the `./k8s-infra/aws-efs-csi-driver-service-account.yaml` manifest by
 replacing `"arn:aws:iam::878179636352:role/mb-eks-efs-csi-driver-role"` with your own role ARN:
@@ -72,7 +91,7 @@ the filesystem ID from your environment and apply:
     kubectl apply -f k8s-infra/aws-efs-storageclass.yaml
 
 Follow the steps in [./k8s-examples/efs-storage/README.md](./k8s-examples/efs-storage/README.md) to
-verify persistent volumes and storage claims can be utilized in your cluster.
+verify that EFS persistent volumes and storage claims can be utilized in your cluster.
 
 
 ### 3. Configure the AWS Load Balancer Controller Add-On

--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -10,6 +10,9 @@ module "eks" {
   cluster_endpoint_public_access = true
 
   cluster_addons = {
+    aws-ebs-csi-driver = {
+      most_recent = true
+    }
     coredns = {
       most_recent = true
     }
@@ -31,9 +34,9 @@ module "eks" {
 
       instance_types = [var.node_group_instance_type]
 
-      min_size     = 1
-      max_size     = 3
-      desired_size = 1
+      min_size     = 2
+      max_size     = 8
+      desired_size = 2
     }
 
     two = {
@@ -41,9 +44,9 @@ module "eks" {
 
       instance_types = [var.node_group_instance_type]
 
-      min_size     = 1
-      max_size     = 3
-      desired_size = 1
+      min_size     = 2
+      max_size     = 8
+      desired_size = 2
     }
   }
 

--- a/iam-policies/eks-aws-load-balancer-controller-policy.json
+++ b/iam-policies/eks-aws-load-balancer-controller-policy.json
@@ -1,0 +1,219 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateServiceLinkedRole"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAddresses",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInternetGateways",
+        "ec2:DescribeVpcs",
+        "ec2:DescribeVpcPeeringConnections",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeInstances",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeTags",
+        "ec2:GetCoipPoolUsage",
+        "ec2:DescribeCoipPools",
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeLoadBalancerAttributes",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeListenerCertificates",
+        "elasticloadbalancing:DescribeSSLPolicies",
+        "elasticloadbalancing:DescribeRules",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetGroupAttributes",
+        "elasticloadbalancing:DescribeTargetHealth",
+        "elasticloadbalancing:DescribeTags"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cognito-idp:DescribeUserPoolClient",
+        "acm:ListCertificates",
+        "acm:DescribeCertificate",
+        "iam:ListServerCertificates",
+        "iam:GetServerCertificate",
+        "waf-regional:GetWebACL",
+        "waf-regional:GetWebACLForResource",
+        "waf-regional:AssociateWebACL",
+        "waf-regional:DisassociateWebACL",
+        "wafv2:GetWebACL",
+        "wafv2:GetWebACLForResource",
+        "wafv2:AssociateWebACL",
+        "wafv2:DisassociateWebACL",
+        "shield:GetSubscriptionState",
+        "shield:DescribeProtection",
+        "shield:CreateProtection",
+        "shield:DeleteProtection"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupIngress"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSecurityGroup"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags"
+      ],
+      "Resource": "arn:aws:ec2:*:*:security-group/*",
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": "CreateSecurityGroup"
+        },
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags",
+        "ec2:DeleteTags"
+      ],
+      "Resource": "arn:aws:ec2:*:*:security-group/*",
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:DeleteSecurityGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateTargetGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:DeleteListener",
+        "elasticloadbalancing:CreateRule",
+        "elasticloadbalancing:DeleteRule"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:RemoveTags"
+      ],
+      "Resource": [
+        "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+        "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+      ],
+      "Condition": {
+        "Null": {
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:RemoveTags"
+      ],
+      "Resource": [
+        "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+        "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "elasticloadbalancing:SetIpAddressType",
+        "elasticloadbalancing:SetSecurityGroups",
+        "elasticloadbalancing:SetSubnets",
+        "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:ModifyTargetGroup",
+        "elasticloadbalancing:ModifyTargetGroupAttributes",
+        "elasticloadbalancing:DeleteTargetGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "Null": {
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:DeregisterTargets"
+      ],
+      "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:SetWebAcl",
+        "elasticloadbalancing:ModifyListener",
+        "elasticloadbalancing:AddListenerCertificates",
+        "elasticloadbalancing:RemoveListenerCertificates",
+        "elasticloadbalancing:ModifyRule"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/iam-policies/eks-ebs-csi-driver-policy.json
+++ b/iam-policies/eks-ebs-csi-driver-policy.json
@@ -1,0 +1,133 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSnapshot",
+        "ec2:AttachVolume",
+        "ec2:DetachVolume",
+        "ec2:ModifyVolume",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInstances",
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeTags",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeVolumesModifications"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:snapshot/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": [
+            "CreateVolume",
+            "CreateSnapshot"
+          ]
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteTags"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:snapshot/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "aws:RequestTag/CSIVolumeName": "*"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/CSIVolumeName": "*"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/kubernetes.io/created-for/pvc/name": "*"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteSnapshot"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/CSIVolumeSnapshotName": "*"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteSnapshot"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
+    }
+  ]
+}

--- a/iam.tf
+++ b/iam.tf
@@ -40,17 +40,19 @@ resource "aws_iam_role" "aws-eks-efs-csi-driver-role" {
   description = "IAM role for the efs-csi-controller-sa SA in EKS"
 
   assume_role_policy = jsonencode({
-    Version   = "2012-10-17"
+    Version = "2012-10-17"
+
     Statement = [
       {
         Action = "sts:AssumeRoleWithWebIdentity",
-        Effect   = "Allow"
+        Effect = "Allow"
+
         Principal = {
           Federated = module.eks.oidc_provider_arn
         },
         Condition = {
           StringEquals = {
-            "${module.eks.oidc_provider}:sub": "system:serviceaccount:kube-system:efs-csi-controller-sa"
+            "${module.eks.oidc_provider}:sub" : "system:serviceaccount:kube-system:efs-csi-controller-sa"
           }
         }
       },
@@ -68,28 +70,98 @@ resource "aws_iam_role" "aws-eks-efs-csi-driver-role" {
   }
 }
 
-resource "aws_iam_role" "aws-load-balancer-controller-iam-role" {
-  name        = "${var.resource_prefix}-load-balancer-controller-role"
-  description = "IAM role for the aws-load-balancer-controller SA in EKS"
+resource "aws_iam_policy" "aws-eks-ebs-csi-driver-policy" {
+  name        = "${var.resource_prefix}-ebs-csi-driver-policy"
+  description = "EKS EBS CSI driver policy for efs-csi-controller-sa SA"
+
+  policy = file("iam-policies/eks-ebs-csi-driver-policy.json")
+
+  tags = {
+    Origin         = var.common_origin_tag
+    ResourcePrefix = var.resource_prefix
+    Owner          = var.common_owner_tag
+    Purpose        = var.common_purpose_tag
+    Stack          = var.common_stack_tag
+  }
+}
+
+resource "aws_iam_role" "aws-eks-ebs-csi-driver-role" {
+  name        = "${var.resource_prefix}-ebs-csi-driver-role"
+  description = "IAM role for the ebs-csi-controller-sa SA in EKS"
 
   assume_role_policy = jsonencode({
-    Version   = "2012-10-17"
+    Version = "2012-10-17"
+
     Statement = [
       {
         Action = "sts:AssumeRoleWithWebIdentity",
-        Effect   = "Allow"
+        Effect = "Allow"
+
         Principal = {
           Federated = module.eks.oidc_provider_arn
         },
         Condition = {
           StringEquals = {
-            "${module.eks.oidc_provider}:aud": "sts.amazonaws.com"
-            "${module.eks.oidc_provider}:sub": "system:serviceaccount:kube-system:aws-load-balancer-controller"
+            "${module.eks.oidc_provider}:aud" : "sts.amazonaws.com",
+            "${module.eks.oidc_provider}:sub" : "system:serviceaccount:kube-system:ebs-csi-controller-sa"
           }
         }
       },
     ]
   })
+
+  managed_policy_arns = [aws_iam_policy.aws-eks-ebs-csi-driver-policy.arn]
+
+  tags = {
+    Origin         = var.common_origin_tag
+    ResourcePrefix = var.resource_prefix
+    Owner          = var.common_owner_tag
+    Purpose        = var.common_purpose_tag
+    Stack          = var.common_stack_tag
+  }
+}
+
+resource "aws_iam_policy" "aws-load-balancer-controller-policy" {
+  name        = "${var.resource_prefix}-aws-load-balancer-controller-policy"
+  description = "EKS ELB controller policy for the aws-load-balancer-controller SA"
+
+  policy = file("iam-policies/eks-aws-load-balancer-controller-policy.json")
+
+  tags = {
+    Origin         = var.common_origin_tag
+    ResourcePrefix = var.resource_prefix
+    Owner          = var.common_owner_tag
+    Purpose        = var.common_purpose_tag
+    Stack          = var.common_stack_tag
+  }
+}
+
+resource "aws_iam_role" "aws-load-balancer-controller-role" {
+  name        = "${var.resource_prefix}-load-balancer-controller-role"
+  description = "IAM role for the aws-load-balancer-controller SA in EKS"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Effect = "Allow"
+
+        Principal = {
+          Federated = module.eks.oidc_provider_arn
+        },
+        Condition = {
+          StringEquals = {
+            "${module.eks.oidc_provider}:aud" : "sts.amazonaws.com"
+            "${module.eks.oidc_provider}:sub" : "system:serviceaccount:kube-system:aws-load-balancer-controller"
+          }
+        }
+      },
+    ]
+  })
+
+  managed_policy_arns = [aws_iam_policy.aws-load-balancer-controller-policy.arn]
 
   tags = {
     Origin         = var.common_origin_tag

--- a/k8s-examples/ebs-storage/README.md
+++ b/k8s-examples/ebs-storage/README.md
@@ -1,0 +1,49 @@
+
+# Deploying the Pod with EBS PersistentVolumeClaim to AWS EKS
+
+## How to Deploy and Verify, Step by Step
+
+*Prerequisites:* Have the EKS cluster set up with AWS Elastic Block Storage per the instructions in
+the [root README.md](../../README.md).
+
+Change directory to `./k8s-examples/ebs-storage/` and apply the Pod and PersistentVolumeClaim config:
+
+    cd k8s-examples/ebs-storage/
+    kubectl apply -f pod-with-pvc.yml
+
+Get the EBS CSI controller pod names:
+
+    kubectl get pods -n kube-system | grep ebs-csi-controller
+    "ebs-csi-controller-746b99cfc-8pvjj              6/6     Running   0          12m"
+    "ebs-csi-controller-746b99cfc-zsbls              6/6     Running   0          12m"
+
+Check the logs from the two pods from the previous command:
+
+    kubectl logs deployment/ebs-csi-controller -n kube-system -c csi-provisioner --tail 10
+
+Confirm that a persistent volume was created with status of `Bound` to a `PersistentVolumeClaim`:
+
+    kubectl get pv
+
+View details about the `PersistentVolumeClaim` that was created:
+
+    kubectl get pvc
+
+View the sample app pod's status until the `STATUS` becomes `Running`.
+
+    kubectl get pods -o wide
+
+Confirm that the data is written to the volume:
+
+    kubectl exec ebs-app -- bash -c "cat data/out.txt"
+
+Delete the pod and then create it again:
+
+    kubectl delete pods/ebs-app --now
+    kubectl apply -f pod-with-pvc.yml
+
+Verify that the old data is still attached and appended to:
+
+    kubectl exec ebs-app -- bash -c "cat data/out.txt"
+
+Now go celebrate! :boom:

--- a/k8s-examples/ebs-storage/pod-with-pvc.yml
+++ b/k8s-examples/ebs-storage/pod-with-pvc.yml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ebs-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ebs-sc
+  resources:
+    requests:
+      storage: 4Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ebs-app
+spec:
+  containers:
+    - name: app
+      image: centos
+      command: ["/bin/sh"]
+      args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
+      volumeMounts:
+        - name: persistent-storage
+          mountPath: /data
+  volumes:
+    - name: persistent-storage
+      persistentVolumeClaim:
+        claimName: ebs-claim

--- a/k8s-examples/efs-storage/README.md
+++ b/k8s-examples/efs-storage/README.md
@@ -1,5 +1,5 @@
 
-# Deploying the Pod with PersistentVolumeClaim to AWS EKS
+# Deploying the Pod with EFS PersistentVolumeClaim to AWS EKS
 
 ## How to Deploy and Verify, Step by Step
 

--- a/k8s-infra/aws-ebs-csi-driver-service-account.yaml
+++ b/k8s-infra/aws-ebs-csi-driver-service-account.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: aws-ebs-csi-driver
+  name: ebs-csi-controller-sa
+  namespace: kube-system
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::878179636352:role/mb-eks-ebs-csi-driver-role

--- a/k8s-infra/aws-ebs-storageclass.yaml
+++ b/k8s-infra/aws-ebs-storageclass.yaml
@@ -1,0 +1,6 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ebs-sc
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ locals {
 
 data "aws_eks_cluster" "default" {
   name = local.cluster_name
+
   depends_on = [module.eks]
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,12 +31,17 @@ output "cluster_oidc_arn" {
 
 output "iam_aws_load_balancer_service_account_arn" {
   description = "AWS IAM ARN for the aws-load-balancer-controller SA"
-  value       = aws_iam_role.aws-load-balancer-controller-iam-role.arn
+  value       = aws_iam_role.aws-load-balancer-controller-role.arn
 }
 
 output "iam_aws_efs_csi_driver_service_account_arn" {
   description = "AWS IAM ARN for the efs-csi-controller-sa SA"
   value       = aws_iam_role.aws-eks-efs-csi-driver-role.arn
+}
+
+output "iam_aws_ebs_csi_driver_service_account_arn" {
+  description = "AWS IAM ARN for the ebs-csi-controller-sa SA"
+  value       = aws_iam_role.aws-eks-ebs-csi-driver-role.arn
 }
 
 output "efs_fs_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -55,7 +55,7 @@ variable "eks_ami_type" {
 
 variable "node_group_instance_type" {
   description = "Type of AWS EKS node group instances to provision"
-  default     = "t3.small"
+  default     = "t3.medium"
 }
 
 variable "common_origin_tag" {


### PR DESCRIPTION
- Bump node group instance type from `t3.small` to `t3.medium` and use 4 nodes instead of 2 (hitting the limit of 11 pods for the smaller instance)
- Add configuration steps for configuring persistent storage, following the [Amazon EBS CSI Driver User Guide](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html)