### PR TITLE
Yet Another K8s Example; Deploying a Storage Dependent App

### DIFF
--- a/k8s-examples/viewspot-logrx/0-infra.yml
+++ b/k8s-examples/viewspot-logrx/0-infra.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/name: viewspot
+  name: viewspot

--- a/k8s-examples/viewspot-logrx/1-logrx-config.yml
+++ b/k8s-examples/viewspot-logrx/1-logrx-config.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: viewspot-logrx
+  name: logrx-server-config
+  namespace: viewspot
+data:
+  LOGRX_ATTCUAT_AUDIT_LOG_ENABLED: "false"
+  LOGRX_ATTCUAT_AUDIT_LOG_ASLA_LOG_ID: ""
+  LOGRX_QA_MODE_ENABLED: "false"
+  LOGRX_KAFKA_BROKERS: ""
+  LOGRX_KAFKA_TOPIC_VBIv1: ""
+  LOGRX_KAFKA_TOPIC_VBIv2: ""
+  LOGRX_KAFKA_TOPIC_VBIv3: ""
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: viewspot-logrx
+  name: logrx-cron-config
+  namespace: viewspot
+data:
+  LOGRX_S3_BUCKET: s3://logrx
+  LOGRX_S3_UPLOAD_SCRIPT: compress_and_copy.sh
+  LOGRX_QS_LOGS_DIR: /opt/viewspot/logrx/data/qs_logs
+  LOGRX_QS_FILE_RETENTION_MINUTES: "10080"

--- a/k8s-examples/viewspot-logrx/2-logrx-server.yml
+++ b/k8s-examples/viewspot-logrx/2-logrx-server.yml
@@ -1,0 +1,163 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/name: viewspot-logrx
+  name: logrx-efs-claim
+  namespace: viewspot
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: efs-sc
+  resources:
+    requests:
+      storage: 40Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: viewspot-logrx
+  name: logrx-server
+  namespace: viewspot
+spec:
+  replicas: 2
+  strategy:
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name: logrx-server
+  template:
+    metadata:
+      labels:
+        name: logrx-server
+    spec:
+      imagePullSecrets:
+        - name: viewspot-artifactory-ro
+      containers:
+        - name: app
+          image: smithmicro-viewspot-docker-release-local.jfrog.io/viewspot-logrx-server:6.0.0p1
+          imagePullPolicy: IfNotPresent
+          command: [ "/bin/sh" ]
+          args: [ "-c", "gunicorn logrx:app" ]
+          env:
+            # Application-specific
+            - name: LOGRX_QS_OUTPUT_DIR
+              value: /data
+            - name: LOGRX_ATTCUAT_AUDIT_LOG_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: logrx-server-config
+                  key: LOGRX_ATTCUAT_AUDIT_LOG_ENABLED
+            - name: LOGRX_ATTCUAT_AUDIT_LOG_ASLA_LOG_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: logrx-server-config
+                  key: LOGRX_ATTCUAT_AUDIT_LOG_ASLA_LOG_ID
+            - name: LOGRX_QA_MODE_ENABLED
+              valueFrom:
+                configMapKeyRef:
+                  name: logrx-server-config
+                  key: LOGRX_QA_MODE_ENABLED
+            - name: LOGRX_API_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: logrx-api-access-key
+                  key: access_key
+            - name: LOGRX_KAFKA_BROKERS
+              valueFrom:
+                configMapKeyRef:
+                  name: logrx-server-config
+                  key: LOGRX_KAFKA_BROKERS
+            - name: LOGRX_KAFKA_TOPIC_VBIv1
+              valueFrom:
+                configMapKeyRef:
+                  name: logrx-server-config
+                  key: LOGRX_KAFKA_TOPIC_VBIv1
+            - name: LOGRX_KAFKA_TOPIC_VBIv2
+              valueFrom:
+                configMapKeyRef:
+                  name: logrx-server-config
+                  key: LOGRX_KAFKA_TOPIC_VBIv2
+            - name: LOGRX_KAFKA_TOPIC_VBIv3
+              valueFrom:
+                configMapKeyRef:
+                  name: logrx-server-config
+                  key: LOGRX_KAFKA_TOPIC_VBIv3
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: http
+            failureThreshold: 1
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          resources:
+            limits:
+              memory: 1Gi
+            requests:
+              cpu: 50m
+              memory: 128Mi
+          volumeMounts:
+            - name: logrx-persistent-storage
+              mountPath: /data
+      volumes:
+        - name: logrx-persistent-storage
+          persistentVolumeClaim:
+            claimName: logrx-efs-claim
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: viewspot-logrx
+  name: logrx-server
+  namespace: viewspot
+spec:
+  selector:
+    name: logrx-server
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app.kubernetes.io/name: viewspot-logrx
+  name: logrx-server
+  namespace: viewspot
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-production
+spec:
+  tls:
+    - hosts:
+        - viewspot-logrx.mb-eks.smithmicro.io
+      secretName: viewspot-logrx-tls-secret
+  rules:
+    - host: viewspot-logrx.mb-eks.smithmicro.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: logrx-server
+                port:
+                  number: 80

--- a/k8s-examples/viewspot-logrx/README.md
+++ b/k8s-examples/viewspot-logrx/README.md
@@ -1,0 +1,68 @@
+
+# Deploying the `viewspot-logrx` App to AWS EKS with EFS
+
+*Prerequisites:* Have the EKS cluster, Nginx Ingress Controller, DNS configuration, and AWS Elastic File System Storage
+set up per the instructions in the [root README.md](../../README.md).
+
+
+## 1. Create the App Namespace and Secrets
+
+Change directory to `./k8s-examples/viewspot-logrx/` and create the namespace `"viewspot"`:
+
+    cd k8s-examples/viewspot-logrx/
+    kubectl apply -f 0-infra.yml
+
+Create a secret with the database credentials:
+
+    export LOGRX_API_ACCESS_KEY="theApiAccessKey"
+    kubectl create secret generic -n viewspot \
+      logrx-api-access-key \
+      --from-literal=access_key="${LOGRX_API_ACCESS_KEY}"
+
+
+## 2. Create ConfigMaps for the Application
+
+Review the values in `1-logrx-config.yml` config map and adjust it to fit your deployment, then apply:
+
+    kubectl apply -f 1-logrx-config.yml
+
+
+## 3. Create the Storage, Deployment, Service, and Ingress for `viewspot-logrx`
+
+Modify the `2-logrx-server.yml` manifest and replace all occurrences of
+app domain `"viewspot-logrx.mb-eks.smithmicro.io"` with your own domain name, then apply the application
+deployment, service and ingress resources:
+
+    kubectl apply -f 2-logrx-server.yml
+
+    kubectl get deployments -n viewspot
+    kubectl get services -n viewspot
+    kubectl describe ingress -n viewspot
+
+The `logrx-server` pods should be marked as ready 2/2 and the ingress should list the event message
+_"Successfully created Certificate viewspot-logrx-tls-secret"_.
+
+Verify that a log entry can be posted to `/v1/log`:
+
+    curl -XPOST https://viewspot-logrx.mb-eks.smithmicro.io/v1/log \
+      -d "_model=LG-M430&app_vn=4.5.24&time=1553148000237"
+    echo $?
+
+Verify that a log entry can be posted to `/v2/log` using the API key:
+
+    export LOGRX_API_ACCESS_KEY="theApiAccessKey"
+    curl -v -XPOST https://viewspot-logrx.mb-eks.smithmicro.io/v2/log \
+      -H "X-Api-Access-Key: $LOGRX_API_ACCESS_KEY" \
+      -d "_model=LG-M430&app_vn=4.5.24&time=1553148000237"
+
+Verify that the server returns its build version, host and startup time:
+
+    curl -XGET https://viewspot-logrx.mb-eks.smithmicro.io/_config | jq .
+
+Get the name of one of the `logrx-server` pods and use it to print the data recorded on storage:
+
+    kubectl get pods -n viewspot
+    export LOGRX_POD_NAME=logrx-server-6f9dbc747f-kh78j
+    kubectl exec -n viewspot $LOGRX_POD_NAME -- bash -c "wc -l /data/* && cat /data/*.qs"
+
+**TODO:** Configure the cron jobs to sync up logs to S3, or stick with streaming to Kafka...? :thinking:


### PR DESCRIPTION
Add Kubernetes manifests and setup instructions for deploying the `viewspot-logrx` app on the EKS cluster.