### PR TITLE
December 2023 Refresh

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -23,7 +23,7 @@ jobs:
         uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: ~1.3.6
-          cli_config_credentials_token: ${{ secrets.TF_TOKEN }}
+          cli_config_credentials_token: ${{ secrets.TF_TOKEN2 }}
 
       - uses: tchupp/actions-terraform-pr@v1
         with:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -19,12 +19,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1
-        with:
-          terraform_version: ~1.3.6
-          cli_config_credentials_token: ${{ secrets.TF_TOKEN2 }}
-
-      - uses: tchupp/actions-terraform-pr@v1
-        with:
-          pr-comment-title: 'for Cloud Workspace in Org "mblomdahl":'
+#      - name: Setup Terraform
+#        uses: hashicorp/setup-terraform@v1
+#        with:
+#          terraform_version: ~1.3.6
+#          cli_config_credentials_token: ${{ secrets.TF_TOKEN2 }}
+#
+#      - uses: tchupp/actions-terraform-pr@v1
+#        with:
+#          pr-comment-title: 'for Cloud Workspace in Org "mblomdahl":'

--- a/README.md
+++ b/README.md
@@ -268,3 +268,12 @@ your own role ARN and `"eu-north-1"` with your own region:
 
 Follow the setup steps in [./k8s-examples/vs-studio/README.md](./k8s-examples/vs-studio/README.md) to
 deploy a feature complete Node application with binary assets on S3.
+
+
+### 10. Configure Access for a DevOps Team
+
+Create the `vs7` namespace and RBAC roles `vs7-developer-global-viewer-role` and `vs7-developer-ns-admin-role`:
+
+    kubectl create ns vs7
+    kubectl apply -f k8s-infra/vs7-developer-global-viewer-role.yaml
+    kubectl apply -f k8s-infra/vs7-developer-ns-admin-role.yaml

--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "19.4.2"
 
   cluster_name    = local.cluster_name
-  cluster_version = "1.24"
+  cluster_version = "1.28"
 
   vpc_id                         = module.vpc.vpc_id
   subnet_ids                     = module.vpc.private_subnets
@@ -58,6 +58,14 @@ module "eks" {
       userarn  = "arn:aws:iam::878179636352:user/mats.blomdahl"
       username = "mblomdahl"
       groups   = ["system:masters"]
+    }
+  ]
+
+  aws_auth_roles = [
+    {
+      rolearn  = "arn:aws:iam::878179636352:role/mb-eks-vs7-developer-role"
+      username = "vs7-developer-role"
+      groups   = ["vs7-developers"]
     }
   ]
 

--- a/eks-studio-sa.tf
+++ b/eks-studio-sa.tf
@@ -32,9 +32,11 @@ resource "aws_iam_role" "aws-eks-viewspot-studio-sa-role" {
   ]
 
   inline_policy {
-    name   = "studio-sa-s3-policy"
+    name = "studio-sa-s3-policy"
+
     policy = jsonencode({
-      Version   = "2012-10-17"
+      Version = "2012-10-17"
+
       Statement = [
         {
           Effect   = "Allow"

--- a/eks-vs7-developer-role.tf
+++ b/eks-vs7-developer-role.tf
@@ -1,0 +1,54 @@
+resource "aws_iam_role" "aws-eks-vs7-developer-role" {
+  name        = "${var.resource_prefix}-vs7-developer-role"
+  description = "IAM role for developer access in EKS"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow"
+
+        Principal = {
+          AWS = var.account_id
+        },
+        Condition = {}
+      },
+    ]
+  })
+
+  inline_policy {
+    name   = "developer-eks-policy"
+    policy = jsonencode({
+      Version   = "2012-10-17"
+      Statement = [
+        {
+          Effect   = "Allow"
+          Action   = [
+            "eks:ListClusters",
+            "eks:DescribeCluster",
+          ]
+          Resource = "arn:aws:eks:*:${var.account_id}:cluster/*"
+        },
+        {
+          Effect   = "Allow"
+          Action   = [
+            "eks:AccessKubernetesApi",
+            "eks:Describe",
+            "eks:List"
+          ]
+          Resource = "arn:aws:eks:*:${var.account_id}:*${var.resource_prefix}*"
+        },
+      ]
+    })
+  }
+
+  tags = {
+    Origin         = var.common_origin_tag
+    ResourcePrefix = var.resource_prefix
+    Owner          = var.common_owner_tag
+    Purpose        = var.common_purpose_tag
+    Stack          = var.common_stack_tag
+  }
+}

--- a/eks-vs7-developer-role.tf
+++ b/eks-vs7-developer-role.tf
@@ -19,21 +19,23 @@ resource "aws_iam_role" "aws-eks-vs7-developer-role" {
   })
 
   inline_policy {
-    name   = "developer-eks-policy"
+    name = "developer-eks-policy"
+
     policy = jsonencode({
-      Version   = "2012-10-17"
+      Version = "2012-10-17"
+
       Statement = [
         {
-          Effect   = "Allow"
-          Action   = [
+          Effect = "Allow"
+          Action = [
             "eks:ListClusters",
             "eks:DescribeCluster",
           ]
           Resource = "arn:aws:eks:*:${var.account_id}:cluster/*"
         },
         {
-          Effect   = "Allow"
-          Action   = [
+          Effect = "Allow"
+          Action = [
             "eks:AccessKubernetesApi",
             "eks:Describe",
             "eks:List"

--- a/k8s-infra/vs7-developer-global-viewer-role.yaml
+++ b/k8s-infra/vs7-developer-global-viewer-role.yaml
@@ -1,0 +1,133 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vs7-developer-global-viewer-role
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - endpoints
+      - limitranges
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - podtemplates
+      - pods
+      - resourcequotas
+      - secrets
+      - services
+      - serviceaccounts
+    verbs:
+      - list
+
+  - apiGroups: [""]
+    resources:
+      - events
+      - nodes
+    verbs: ["list", "get", "watch"]
+
+  - apiGroups: ["apps"]
+    resources:
+      - replicasets
+      - deployments
+      - statefulsets
+      - daemonsets
+    verbs: ["list"]
+
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["list"]
+
+  - apiGroups: ["autoscaling"]
+    resources:
+      - horizontalpodautoscalers
+    verbs: ["list"]
+
+  - apiGroups: ["extensions"]
+    resources:
+      - ingresses
+      - deployments
+      - daemonsets
+      - replicasets
+      - services
+      - configmaps
+    verbs: ["list", "get", "watch"]
+
+  - apiGroups: ["policy"]
+    resources:
+      - poddisruptionbudgets
+    verbs: ["list"]
+
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+      - ingressclasses
+      - status
+      - networkpolicies
+    verbs: ["list"]
+
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - storageclasses
+      - volumeattachments
+      - csidrivers
+      - csinodes
+      - csistoragecapacities
+    verbs: ["list"]
+
+  - apiGroups: ["apiregistration.k8s.io"]
+    resources:
+      - apiservices
+    verbs: ["list"]
+
+  - apiGroups: ["coordination.k8s.io"]
+    resources:
+      - leases
+    verbs: ["list"]
+
+  - apiGroups: ["discovery.k8s.io"]
+    resources:
+      - endpointslices
+    verbs: ["list"]
+
+  - apiGroups: ["node.k8s.io"]
+    resources:
+      - runtimeclasses
+    verbs: ["list"]
+
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources:
+      - clusterroles
+      - clusterrolebindings
+      - roles
+      - rolebindings
+    verbs: ["list"]
+
+  - apiGroups: ["scheduling.k8s.io"]
+    resources:
+      - priorityclasses
+    verbs: ["list"]
+
+  - apiGroups: ["flowcontrol.apiserver.k8s.io"]
+    resources:
+      - flowschemas
+      - prioritylevelconfigurations
+    verbs: ["list"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vs7-developer-global-viewer-rolebinding
+subjects:
+  - kind: User
+    name: vs7-developer-role
+    namespace: vs7
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name:  vs7-developer-global-viewer-role
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s-infra/vs7-developer-ns-admin-role.yaml
+++ b/k8s-infra/vs7-developer-ns-admin-role.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: vs7
+  name: vs7-developer-ns-admin-role
+rules:
+  - apiGroups:
+      - vs7
+    resources:
+      - pods
+      - pods/log
+      - pods/status
+      - deployments
+      - replicasets
+      - services
+      - secrets
+      - configmaps
+      - podtemplates
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: vs7
+  name: vs7-developer-ns-admin-rolebinding
+subjects:
+  - kind: User
+    name: vs7-developer-role
+    namespace: vs7
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: vs7-developer-ns-admin-role
+  apiGroup: rbac.authorization.k8s.io
+---

--- a/variables.tf
+++ b/variables.tf
@@ -55,7 +55,7 @@ variable "eks_ami_type" {
 
 variable "node_group_instance_type" {
   description = "Type of AWS EKS node group instances to provision"
-  default     = "t3.medium"
+  default     = "t3.large"
 }
 
 variable "common_origin_tag" {


### PR DESCRIPTION
- Bigger better cluster, `t3.large`
- Updated Kubernetes version incrementally from 1.24 to 1.28
- New RBAC roles `vs7-developer-global-viewer-role` and `vs7-developer-ns-admin-role` for the cluster, backed by new IAM role `${var.resource_prefix}-vs7-developer-role`